### PR TITLE
accountservice: remove pk on sessions.user

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/account/AccountService.java
+++ b/http-service/src/main/java/net/runelite/http/service/account/AccountService.java
@@ -68,7 +68,7 @@ public class AccountService
 	private static final String EMAIL_HASH_SALT = "runelite";
 
 	private static final String CREATE_SESSIONS = "CREATE TABLE IF NOT EXISTS `sessions` (\n"
-		+ "  `user` int(11) NOT NULL PRIMARY KEY,\n"
+		+ "  `user` int(11) NOT NULL,\n"
 		+ "  `uuid` varchar(36) NOT NULL,\n"
 		+ "  `created` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"
 		+ "  `last_used` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,\n"


### PR DESCRIPTION
the pk on user prevented multiple sessions for a single user and was swallowed by the insert ignore, returning a ghost session id which was lost on restart

this issue was never present in prod, just a mismatch between the repo code and prod db