### PR TITLE
pluginhub: add endpoints for generating shields.io badges

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/pluginhub/PluginHubController.java
+++ b/http-service/src/main/java/net/runelite/http/service/pluginhub/PluginHubController.java
@@ -46,6 +46,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,6 +85,52 @@ public class PluginHubController
 		return ResponseEntity.ok()
 			.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
 			.body(pluginCounts);
+	}
+
+	@GetMapping("/shields/installs/plugin/{pluginName}")
+	public ResponseEntity<ShieldsFormat> installs(@PathVariable String pluginName)
+	{
+		if (pluginCounts.isEmpty())
+		{
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+				.cacheControl(CacheControl.noCache())
+				.build();
+		}
+
+		long count = pluginCounts.getOrDefault(pluginName, -1L);
+		return ResponseEntity.ok()
+			.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
+			.body(new ShieldsFormat(count, "Total installs"));
+	}
+
+	@GetMapping("/shields/rank/plugin/{pluginName}")
+	public ResponseEntity<ShieldsFormat> rank(@PathVariable String pluginName)
+	{
+		if (pluginCounts.isEmpty())
+		{
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+				.cacheControl(CacheControl.noCache())
+				.build();
+		}
+
+
+		long rank = -1;
+		long installs = pluginCounts.getOrDefault(pluginName, -1L);
+		if (installs != -1L)
+		{
+			rank = 1;
+			for (Map.Entry<String, Long> entry : pluginCounts.entrySet())
+			{
+				if (entry.getValue() > installs)
+				{
+					rank++;
+				}
+			}
+		}
+
+		return ResponseEntity.ok()
+			.cacheControl(CacheControl.maxAge(30, TimeUnit.MINUTES).cachePublic())
+			.body(new ShieldsFormat(rank, "Plugin rank"));
 	}
 
 	@PostMapping

--- a/http-service/src/main/java/net/runelite/http/service/pluginhub/ShieldsFormat.java
+++ b/http-service/src/main/java/net/runelite/http/service/pluginhub/ShieldsFormat.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, TheStonedTurtle <https://github.com/TheStonedTurtle>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.http.service.pluginhub;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class ShieldsFormat
+{
+	int schemaVersion;
+	String label;
+	String message;
+	String color;
+	boolean isError;
+
+	public ShieldsFormat(long count, String label)
+	{
+		this(1, label, String.valueOf(count), count > 0 ? "007bff" : "red", count < 0);
+	}
+}


### PR DESCRIPTION
Adds two new endpoints to the `pluginhub` portion of the API which can be used with https://shields.io to generate README badges for Github pages.  These endpoints would be used with the `Endpoint Badges` portion of the shields.io website (https://shields.io/badges/endpoint-badge)

I'm not sure if this is actually feasible within this API as the `runlite-{version}` part will change with every release but I figured I'd PR it anyway. Maybe the API can support `latest-release` as a version to support this PR? If not feel free to close this.

1) `/shields/installs/plugin/{pluginName}`
2) `/shields/rank/plugin/{pluginName}`

Example shields.io format (assuming `latest-release` would work):
`https://img.shields.io/endpoint?url=https://api.runelite.net/latest-release/pluginhub/shields/installs/plugin/quest-helper`

I copied these URL paths from my personal website, if they are too verbose let me know and I can change them.

I was able to test this functionality through IntelliJ Ultimate Edition. I used the below `generated-requests.http` file to populate dummy data:
```http
###
POST http://localhost:8080/pluginhub
Content-Type: application/json
X-Forwarded-For: 127.0.0.1

["test", "test1"]

###
POST http://localhost:8080/pluginhub
Content-Type: application/json
X-Forwarded-For: 127.0.0.2

["test", "test2"]

###
POST http://localhost:8080/pluginhub
Content-Type: application/json
X-Forwarded-For: 127.0.0.3

["test", "test3"]

###
POST http://localhost:8080/pluginhub
Content-Type: application/json
X-Forwarded-For: 127.0.0.4

["test", "test4"]

###
POST http://localhost:8080/pluginhub
Content-Type: application/json
X-Forwarded-For: 127.0.0.5

["test", "test5"]
```
`pluginhub` endpoint (unchanged)
![image](https://github.com/runelite/api.runelite.net/assets/29030969/d67a9a28-6494-4c63-9852-bf17d6598e58)

plugin value exists:
![image](https://github.com/runelite/api.runelite.net/assets/29030969/7cd266c0-63df-4e20-b09e-eed3a4a394cd)
![image](https://github.com/runelite/api.runelite.net/assets/29030969/fca6fc34-d6fe-46f4-b99d-ae57bae41dbe)

plugin value does not exist:
![image](https://github.com/runelite/api.runelite.net/assets/29030969/d421f7a3-dad5-40b1-9a47-8704580f9822)
![image](https://github.com/runelite/api.runelite.net/assets/29030969/4d49eb8a-9450-4895-8ae0-25ded0686003)
