### PR TITLE
Lowercase plugin name for shield.io urls

### DIFF
--- a/http-service/src/main/java/net/runelite/http/service/pluginhub/PluginHubController.java
+++ b/http-service/src/main/java/net/runelite/http/service/pluginhub/PluginHubController.java
@@ -90,6 +90,7 @@ public class PluginHubController
 	@GetMapping("/shields/installs/plugin/{pluginName}")
 	public ResponseEntity<ShieldsFormat> installs(@PathVariable String pluginName)
 	{
+		pluginName = pluginName.toLowerCase();
 		if (pluginCounts.isEmpty())
 		{
 			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
@@ -106,6 +107,7 @@ public class PluginHubController
 	@GetMapping("/shields/rank/plugin/{pluginName}")
 	public ResponseEntity<ShieldsFormat> rank(@PathVariable String pluginName)
 	{
+		pluginName = pluginName.toLowerCase();
 		if (pluginCounts.isEmpty())
 		{
 			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)


### PR DESCRIPTION
It seems like the plugin names are always lowercased in the API, causing the below URL to fail:
https://api.runelite.net/pluginhub/shields/rank/plugin/Player-Outline

Where once you lowercase `Player-Outline` the url works just fine:
https://api.runelite.net/pluginhub/shields/rank/plugin/player-outline

This PR fixes this by always lowercasing the parameter before getting the value from the map.

